### PR TITLE
Add possibility to select sound card

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ exports.start = function (options) {
   // Spawn audio capture command
   cmdOptions = { encoding: 'binary' }
   if (options.device) {
-    cmdOptions.env = { AUDIODEV: options.device }
+    cmdOptions.env = Object.assign({}, process.env, { AUDIODEV: options.device })
   }
   cp = spawn(cmd, cmdArgs, cmdOptions)
   var rec = cp.stdout

--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ exports.start = function (options) {
         '-'                       // pipe
       ]
       if (options.device) {
-        cmdArgs.unshift('-D', device)
+        cmdArgs.unshift('-D', options.device)
       }
       break
   }
@@ -60,7 +60,7 @@ exports.start = function (options) {
   // Spawn audio capture command
   cmdOptions = { encoding: 'binary' }
   if (options.device) {
-    cmdOptions.env = { AUDIODEV: device }
+    cmdOptions.env = { AUDIODEV: options.device }
   }
   cp = spawn(cmd, cmdArgs, cmdOptions)
   var rec = cp.stdout

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ exports.start = function (options) {
   options = Object.assign(defaults, options)
 
   // Capture audio stream
-  var cmd, cmdArgs
+  var cmd, cmdArgs, cmdOptions
   switch (options.recordProgram) {
     // On some Windows machines, sox is installed using the "sox" binary
     // instead of "rec"
@@ -51,11 +51,18 @@ exports.start = function (options) {
         '-f', 'S16_LE',           // Sample format
         '-'                       // pipe
       ]
+      if (options.device) {
+        cmdArgs.unshift('-D', device)
+      }
       break
   }
 
   // Spawn audio capture command
-  cp = spawn(cmd, cmdArgs, { encoding: 'binary' })
+  cmdOptions = { encoding: 'binary' }
+  if (options.device) {
+    cmdOptions.env = { AUDIODEV: device }
+  }
+  cp = spawn(cmd, cmdArgs, cmdOptions)
   var rec = cp.stdout
 
   if (options.verbose) {


### PR DESCRIPTION
In my case I have multiple microphones attached and needed a way to select the sound card.

sox/rec uses an environment variable called ``AUDIODEV`` while arecord offers a command line parameter to configure it. 

@ maintainer: Thanks for your great work.