### PR TITLE
Add options for silence cutoff and individualized thresholds

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,15 @@ This module requires you to install [SoX](http://sox.sourceforge.net) and it mus
 ```
 sampleRate    : 16000  // audio sample rate
 threshold     : 0.5    // silence threshold (rec only)
+thresholdStart: null   // silence threshold to start recording, overrides threshold (rec only)
+thresholdEnd  : null   // silence threshold to end recording, overrides threshold (rec only)
+silence       : '1.0'  // seconds of silence before ending
 verbose       : false  // log info to the console
 recordProgram : 'rec'  // Defaults to 'rec' - also supports 'arecord' and 'sox'
 device        : null   // recording device (e.g.: 'plughw:1')
 ```
 
-> Please note that `arecord` might not work on all operating systems. If you can't capture any sound with `arecord`, try to change device (`arecord -l`). 
+> Please note that `arecord` might not work on all operating systems. If you can't capture any sound with `arecord`, try to change device (`arecord -l`).
 
 ## Usage
 

--- a/index.js
+++ b/index.js
@@ -12,6 +12,9 @@ exports.start = function (options) {
     sampleRate: 16000,
     compress: false,
     threshold: 0.5,
+    thresholdStart: null,
+    thresholdEnd: null,
+    silence: '1.0',
     verbose: false,
     recordProgram: 'rec'
   }
@@ -36,8 +39,8 @@ exports.start = function (options) {
         '-t', 'wav',              // audio type
         '-',                      // pipe
             // end on silence
-        'silence', '1', '0.1', options.threshold + '%',
-        '1', '1.0', options.threshold + '%'
+        'silence', '1', '0.1', options.thresholdStart || options.threshold + '%',
+        '1', options.silence, options.thresholdEnd || options.threshold + '%'
       ]
       break
     // On some systems (RasPi), arecord is the prefered recording binary


### PR DESCRIPTION
For our project, we found that using the current 'silence' parameters was insufficient - we needed some cases where we could allow a pause of longer than 1s before recording was cut off, and we wanted the activation threshold to be different from the cutoff threshold.

I added additional options to support this, with defaults.
Additionally, the current option for `threshold`, if provided, will still continue to work as it does in the existing version and apply to both activation and cutoff.