### PR TITLE
Throw an error when we receive data from stderr

### DIFF
--- a/examples/file.js
+++ b/examples/file.js
@@ -9,4 +9,7 @@ record.start({
   sampleRate: 44100,
   verbose: true
 })
+.on('error', err => {
+  console.error('stderr said:', err)
+})
 .pipe(file)

--- a/index.js
+++ b/index.js
@@ -81,6 +81,10 @@ exports.start = function (options) {
     })
   }
 
+  cp.stderr.on('data', function (data) {
+    rec.emit('error', data.toString())
+  })
+
   return rec
 }
 


### PR DESCRIPTION
Fixes #19 

This might be a breaking change for some folks who were not expecting data from stderr to emit an error.

I've noticed that `sox` writes warnings to stderr as well, so that might make it slightly tricky for users to figure out what to ignore.

Some examples from what `sox` might output as a warning:

```
rec WARN formats: can't set 1 channels; using 2
rec WARN wav: Length in output .wav header will be wrong since can't seek to fix it
```

We could reject output that contains `WARN` and not propagate those? I'm not sure what the behaviour is of `rec` and `arec`.