### PR TITLE
support pause and resume of audio

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,3 +93,21 @@ exports.stop = function () {
   cp.kill() // Exit the spawned process, exit gracefully
   return cp
 }
+
+exports.pause = function () {
+  if (!cp) {
+    console.log('Please start a recording first')
+    return false
+  }
+
+  cp.kill('SIGSTOP')
+}
+
+exports.resume = function() {
+  if (!cp) {
+    console.log('Please start a recording first')
+    return false
+  }
+  
+  cp.kill('SIGCONT')
+}


### PR DESCRIPTION
This is a fix for #37. This instructs the child process to hide it's binary output.

Some other idea that I could use your input on:
- API names: could also be `mute()` and `unmute()` - or something else entirely?
- Could return cp - might not actually want to expose this, but it is an option
- Verbose logging (could add log messages for these events when verbose logging is on)
- Add state to keep track of pause and add `isPaused()`
- It's not very DRY, which could be easily fixed