### PR TITLE
Fixed sox recording

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,27 +17,45 @@ exports.start = function (options) {
     thresholdEnd: null,
     silence: '1.0',
     verbose: false,
-    recordProgram: 'rec'
+    recordProgram: 'sox'
   }
 
   options = Object.assign(defaults, options)
 
   // Capture audio stream
-  var cmd, cmdArgs, cmdOptions
+  var cmd, cmdArgs, cmdOptions, audioType
   switch (options.recordProgram) {
     // On some Windows machines, sox is installed using the "sox" binary
     // instead of "rec"
     case 'sox':
+      cmd = "sox"
+      audioType = "wav"
+      if (options.audioType) audioType = options.audioType
+      if (options.asRaw) audioType = "raw"
+      cmdArgs = [
+        '-q',                                   // show no progress
+        '-t', 'waveaudio',
+        '-d',
+        '-r', options.sampleRate.toString(),    // sample rate
+        '-c', '1',                              // channels
+        '-e', 'signed-integer',                 // sample encoding
+        '-b', '16',                             // precision (bits)
+        '-t', audioType,  // audio type
+        '-'
+      ]
+      break
     case 'rec':
     default:
-      cmd = options.recordProgram
+      cmd = "rec"
+      audioType = "wav"
+      if (options.audioType) audioType = options.audioType
       cmdArgs = [
         '-q',                     // show no progress
         '-r', options.sampleRate, // sample rate
         '-c', options.channels,   // channels
         '-e', 'signed-integer',   // sample encoding
         '-b', '16',               // precision (bits)
-        '-t', 'wav',              // audio type
+        '-t', audioType,              // audio type
         '-',                      // pipe
             // end on silence
         'silence', '1', '0.1', options.thresholdStart || options.threshold + '%',
@@ -47,11 +65,13 @@ exports.start = function (options) {
     // On some systems (RasPi), arecord is the prefered recording binary
     case 'arecord':
       cmd = 'arecord'
+      audioType = "wav"
+      if (options.audioType) audioType = options.audioType
       cmdArgs = [
         '-q',                     // show no progress
         '-r', options.sampleRate, // sample rate
         '-c', options.channels,   // channels
-        '-t', 'wav',              // audio type
+        '-t', audioType,              // audio type
         '-f', 'S16_LE',           // Sample format
         '-'                       // pipe
       ]


### PR DESCRIPTION
Fixed arguments for sox recording. Sox is now default record program. Added option "audioType", that allows receive stream with any supported audio type.