### PR TITLE
Support 'parec' from PulseAudio

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ thresholdStart: null   // silence threshold to start recording, overrides thresh
 thresholdEnd  : null   // silence threshold to end recording, overrides threshold (rec only)
 silence       : '1.0'  // seconds of silence before ending
 verbose       : false  // log info to the console
-recordProgram : 'rec'  // Defaults to 'rec' - also supports 'arecord' and 'sox'
+recordProgram : 'rec'  // Defaults to 'rec' - also supports 'arecord', 'sox' and 'parec'
 device        : null   // recording device (e.g.: 'plughw:1')
 ```
 

--- a/index.js
+++ b/index.js
@@ -73,6 +73,17 @@ exports.start = function (options) {
       if (options.device) {
         cmdArgs.unshift('-D', options.device)
       }
+    // PulseAudio
+    case 'parec':
+      cmd = 'parec'
+      cmdArgs = [
+        '--rate', options.sampleRate,   // sample rate
+        '--channels', options.channels, // channels
+        '--format', 's16le',            // sample format
+      ]
+      if (options.device) {
+        cmdArgs.unshift('--device', options.device)
+      }
       break
   }
 


### PR DESCRIPTION
Native PulseAudio support (parec) enables some use cases not possible with ALSA emulation (arecord), e.g. multiple microphones can be mixed together and recorded simultaneously by node-record-lpcm16