### PR TITLE
Add ability to pass path to binary as option

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,8 @@ class Recording {
       silence: '1.0',
       recorder: 'sox',
       endOnSilence: false,
-      audioType: 'wav'
+      audioType: 'wav',
+      binPath: null,
     }
 
     this.options = Object.assign(defaults, options)

--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ class Recording {
       endOnSilence: false,
       audioType: 'wav',
       binPath: null,
+      bufferSize: null,
       arguments: [],
     }
 

--- a/index.js
+++ b/index.js
@@ -34,7 +34,10 @@ class Recording {
 
     debug(`Started recording`)
     debug(this.options)
-    debug(` ${this.cmd} ${this.args.join(' ')}`)
+
+    const command = ` ${this.cmd} ${this.args.join(' ')}`;
+    debug(command);
+    console.log('Running SOX', command);
 
     return this.start()
   }

--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ class Recording {
       endOnSilence: false,
       audioType: 'wav',
       binPath: null,
+      arguments: [],
     }
 
     this.options = Object.assign(defaults, options)

--- a/recorders/arecord.js
+++ b/recorders/arecord.js
@@ -1,6 +1,10 @@
 // On some systems (RasPi), arecord is the prefered recording binary
 module.exports = (options) => {
-  const cmd = 'arecord'
+  let cmd = 'arecord'
+
+  if (options.binPath) {
+    cmd = options.binPath;
+  }
 
   const args = [
     '-q', // show no progress

--- a/recorders/rec.js
+++ b/recorders/rec.js
@@ -1,5 +1,9 @@
 module.exports = (options) => {
-  const cmd = 'rec'
+  let cmd = 'rec'
+
+  if (options.binPath) {
+    cmd = options.binPath;
+  }
 
   let args = [
     '-q', // show no progress

--- a/recorders/sox.js
+++ b/recorders/sox.js
@@ -23,6 +23,10 @@ module.exports = (options) => {
     ])
   }
 
+  if (options.arguments) {
+    args = args.concat(options.arguments);
+  }
+
   const spawnOptions = { }
 
   if (options.device) {

--- a/recorders/sox.js
+++ b/recorders/sox.js
@@ -16,6 +16,10 @@ module.exports = (options) => {
     '-' // pipe
   ]
 
+  if (options.bufferSize) {
+    args.push('--buffer', options.bufferSize);
+  }
+
   if (options.endOnSilence) {
     args = args.concat([
       'silence', '1', '0.1', options.thresholdStart || options.threshold + '%',

--- a/recorders/sox.js
+++ b/recorders/sox.js
@@ -1,6 +1,10 @@
 module.exports = (options) => {
   let cmd = 'sox'
 
+  if (options.binPath) {
+    cmd = options.binPath;
+  }
+
   let args = [
     '--default-device',
     '--no-show-progress', // show no progress
@@ -11,10 +15,6 @@ module.exports = (options) => {
     '--type', options.audioType, // audio type
     '-' // pipe
   ]
-
-  if (options.binPath) {
-    cmd = options.binPath;
-  }
 
   if (options.endOnSilence) {
     args = args.concat([

--- a/recorders/sox.js
+++ b/recorders/sox.js
@@ -1,5 +1,5 @@
 module.exports = (options) => {
-  const cmd = 'sox'
+  let cmd = 'sox'
 
   let args = [
     '--default-device',
@@ -11,6 +11,10 @@ module.exports = (options) => {
     '--type', options.audioType, // audio type
     '-' // pipe
   ]
+
+  if (options.binPath) {
+    cmd = options.binPath;
+  }
 
   if (options.endOnSilence) {
     args = args.concat([


### PR DESCRIPTION
We use this package to record audio but also ship precompiled binaries for each platform. So I added an option to pass the absolute path to the binary.

We're now using the version from our fork but it would be great if this gets merged and released.